### PR TITLE
Ensure pdf2image uses configured PDF render DPI

### DIFF
--- a/ctv/orc.py
+++ b/ctv/orc.py
@@ -297,7 +297,7 @@ def _read_pdf_from_b64(b64: str, *, decoded_bytes: Optional[bytes] = None) -> Li
             errors.append("pypdfium2: no pages rendered")
 
     try:
-        return convert_from_bytes(decoded_bytes)
+        return convert_from_bytes(decoded_bytes, dpi=PDF_RENDER_DPI)
     except Exception as exc:
         errors.append(f"pdf2image: {exc}")
         raise ValueError("PDF 转图片失败: " + "; ".join(errors))


### PR DESCRIPTION
## Summary
- ensure the pdf2image fallback renderer respects the configured PDF_RENDER_DPI so its output matches pypdfium2

## Testing
- python - <<'PY'  # verifies both pdf2image and pypdfium2 paths scale pages using PDF_RENDER_DPI

------
https://chatgpt.com/codex/tasks/task_b_68ccd4df3920832697a2bb7692dd1202