### PR TITLE
feat: add PDF support to ctv pipeline

### DIFF
--- a/ctv/ocryb.py
+++ b/ctv/ocryb.py
@@ -65,6 +65,10 @@ DET_MAX_SIDE = int(os.getenv("OCR_DET_LIMIT_SIDE", "960"))
 REC_BATCH    = int(os.getenv("OCR_REC_BATCH", "32"))
 # 强制设备（仅用于日志提示）：gpu / cpu（实际设备由 use_gpu & 环境决定）
 PREF_DEV     = os.getenv("OCR_DEVICE", "gpu").lower()
+# 识别语言（可设置为 chinese_cht 等 PaddleOCR 官方语言码）
+OCR_LANG     = os.getenv("OCR_LANG", "ch").strip() or "ch"
+
+print(f"[CONFIG] PaddleOCR lang={OCR_LANG}", file=sys.stderr, flush=True)
 
 # ================== 初始化与回退 ==================
 def init_ocr_prefer_gpu() -> (PaddleOCR, bool):
@@ -75,7 +79,7 @@ def init_ocr_prefer_gpu() -> (PaddleOCR, bool):
             gpu_device = "gpu" if PREF_DEV == "auto" else PREF_DEV
             print(f"[INIT] Try GPU (device={gpu_device})...", file=sys.stderr, flush=True)
             ocr = PaddleOCR(
-                lang="ch",
+                lang=OCR_LANG,
                 use_doc_orientation_classify=False,
                 use_doc_unwarping=False,
                 use_textline_orientation=USE_CLS,
@@ -97,7 +101,7 @@ def init_ocr_prefer_gpu() -> (PaddleOCR, bool):
     # 回退 CPU
     print("[INIT] Fallback to CPU (device=cpu)...", file=sys.stderr, flush=True)
     ocr = PaddleOCR(
-        lang="ch",
+        lang=OCR_LANG,
         use_doc_orientation_classify=False,
         use_doc_unwarping=False,
         use_textline_orientation=USE_CLS,
@@ -157,6 +161,7 @@ def version():
             "cls": USE_CLS,
             "det_limit_side_len": DET_MAX_SIDE,
             "rec_batch_num": REC_BATCH,
+            "lang": OCR_LANG,
         }
     except Exception:
         return {
@@ -164,7 +169,8 @@ def version():
             "paddlepaddle": "unknown",
             "device": "gpu" if USING_GPU else "cpu",
             "use_gpu": USING_GPU,
-            "cls": USE_CLS
+            "cls": USE_CLS,
+            "lang": OCR_LANG,
         }
 
 def _read_image_from_b64(b64: str) -> Image.Image:


### PR DESCRIPTION
## Summary
- allow ctv.py to detect PDF inputs, convert them to images under _ctv_build/pdf_images, and emit progress logs
- add PDF decoding support to the local OCR HTTP server so it can accept base64-encoded PDF payloads
- allow the GPU-first local OCR services to configure PaddleOCR's language via the OCR_LANG environment variable for better traditional Chinese coverage

## Testing
- python -m compileall ctv/ctv.py ctv/orc.py
- python -m compileall ctv/orc.py ctv/ocryb.py

------
https://chatgpt.com/codex/tasks/task_b_68ccfb28591c8326b4b5499557ff238c