### PR TITLE
Adjust PDF handling and log T2S output

### DIFF
--- a/ctv/orc.py
+++ b/ctv/orc.py
@@ -112,6 +112,37 @@ if OCR_LANG_ALIAS:
 else:
     print(f"[CONFIG] PaddleOCR lang={OCR_LANG}", file=sys.stderr, flush=True)
 
+_T2S_CONVERTER = None
+_OPENCC_T2S_ENABLED = OCR_LANG == "chinese_cht"
+if _OPENCC_T2S_ENABLED:
+    try:
+        from opencc import OpenCC  # type: ignore
+
+        _T2S_CONVERTER = OpenCC("t2s").convert
+        print(
+            "[CONFIG] Traditional Chinese output will be converted to Simplified via opencc.",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception as exc:  # pragma: no cover - optional dependency
+        try:
+            from zhconv import convert  # type: ignore
+
+            _T2S_CONVERTER = lambda text: convert(text, "zh-hans")
+            print(
+                "[CONFIG] Traditional Chinese output will be converted to Simplified via zhconv.",
+                file=sys.stderr,
+                flush=True,
+            )
+        except Exception as exc2:  # pragma: no cover - optional dependency
+            print(
+                "[CONFIG][WARN] No T2S converter available (opencc error: "
+                f"{exc}; zhconv error: {exc2}). Traditional text will remain unchanged.",
+                file=sys.stderr,
+                flush=True,
+            )
+            _OPENCC_T2S_ENABLED = False
+
 # ================== 初始化与回退 ==================
 def init_ocr_prefer_gpu() -> (PaddleOCR, bool):
     """优先 GPU 初始化；失败时（如 cuDNN 缺失）自动回退到 CPU，除非 GPU_STRICT=1"""
@@ -234,7 +265,7 @@ def _pdf_bytes_to_image_first_page(raw: bytes) -> Tuple[Image.Image, int]:
         doc.close()
 
 
-def _read_image_from_b64(b64: str) -> Image.Image:
+def _read_image_from_b64(b64: str) -> Tuple[Image.Image, Dict[str, Any]]:
     # 兼容 dataURL
     if b64.strip().lower().startswith("data:"):
         b64 = b64.split(",", 1)[1]
@@ -248,21 +279,75 @@ def _read_image_from_b64(b64: str) -> Image.Image:
         except ValueError as exc:
             raise RuntimeError(str(exc)) from exc
         print(f"[REQ] PDF base64 输入 -> 第 1 页 (共 {total_pages} 页)", file=sys.stderr, flush=True)
-        return img
-    return Image.open(io.BytesIO(raw)).convert("RGB")
+        return img, {"source": "pdf", "page_index": 1, "page_total": total_pages}
+    return Image.open(io.BytesIO(raw)).convert("RGB"), {"source": "image", "page_index": 1, "page_total": 1}
+
+def _cluster_bottom_text_entries(
+    entries: List[Tuple[int, np.ndarray]], image_height: int
+) -> Optional[List[int]]:
+    """基于检测框的纵向位置，将最底部的一段文字行聚为一个簇.
+
+    返回属于底部簇的 entry 索引列表，若无法确定则返回 ``None``。
+    """
+
+    if not entries or image_height <= 0:
+        return None
+
+    # 收集每个文本框的 (top_y, bottom_y) 范围，并按照 top_y 升序排序
+    spans: List[Tuple[int, float, float]] = []
+    for idx, box in entries:
+        if box.size == 0:
+            continue
+        ys = box[..., 1].reshape(-1)
+        spans.append((idx, float(ys.min()), float(ys.max())))
+
+    if not spans:
+        return None
+
+    spans.sort(key=lambda item: item[1])
+    bottom_idx, bottom_top, bottom_bottom = spans[-1]
+    selected = {bottom_idx}
+    cluster_top = bottom_top
+    cluster_bottom = bottom_bottom
+
+    # 从底部向上合并间隔较小的文本行，允许轻微的留白
+    gap_tolerance = max(image_height * 0.02, 8.0)
+    for idx, top, bottom in reversed(spans[:-1]):
+        if cluster_top - bottom > gap_tolerance:
+            break
+        selected.add(idx)
+        cluster_top = min(cluster_top, top)
+        cluster_bottom = max(cluster_bottom, bottom)
+
+    # 若聚合后的底部文本并不靠近图像底部，则认为判断不可靠
+    if cluster_bottom < image_height * 0.45:
+        return None
+
+    # 将所有与该纵向范围有重叠的行都纳入，避免遗漏同一文本块
+    for idx, top, bottom in spans:
+        if idx in selected:
+            continue
+        overlaps = not (bottom < cluster_top or top > cluster_bottom)
+        if overlaps:
+            selected.add(idx)
+
+    return sorted(selected)
+
 
 @app.post("/ocr", response_model=OcrResp)
 def do_ocr(req: OcrReq):
     try:
-        img = _read_image_from_b64(req.image_b64)
+        img, img_meta = _read_image_from_b64(req.image_b64)
         arr = np.array(img)  # HWC, RGB
+
         t0 = time.time()
         result = ocr.predict(arr, use_textline_orientation=USE_CLS)
         dt = time.time() - t0
         print(f"[REQ] one image OK in {dt:.2f}s | device={'GPU' if USING_GPU else 'CPU'} | cls={USE_CLS}",
               file=sys.stderr, flush=True)
 
-        lines: List[Dict[str, Any]] = []
+        parsed_entries: List[Dict[str, Any]] = []
+        box_entries: List[Tuple[int, np.ndarray]] = []
         if result:
             for res in result:
                 data = res
@@ -286,23 +371,77 @@ def do_ocr(req: OcrReq):
                         continue
                     text_clean = text.strip()
                     score = float(scores[idx]) if idx < len(scores) else 0.0
-                    box = None
+                    box_raw = None
                     if isinstance(boxes, (list, tuple)) and idx < len(boxes):
-                        box = boxes[idx]
+                        box_raw = boxes[idx]
                     elif (
                         hasattr(boxes, "__getitem__")
                         and hasattr(boxes, "__len__")
                         and idx < len(boxes)
                     ):
-                        box = boxes[idx]
-                    if box is not None:
-                        box = np.asarray(box).tolist()
+                        box_raw = boxes[idx]
+                    box_arr = None
+                    if box_raw is not None:
+                        box_arr = np.asarray(box_raw, dtype=float)
+                        box_entries.append((len(parsed_entries), box_arr))
+                    parsed_entries.append({
+                        "raw_text": text_clean,
+                        "score": score,
+                        "box_arr": box_arr,
+                    })
+
+        selected_indices: Optional[List[int]] = None
+        skip_bottom_focus = (
+            img_meta.get("source") == "pdf"
+            and img_meta.get("page_index", 1) == 1
+            and img_meta.get("page_total", 1) > 1
+        )
+        if skip_bottom_focus:
+            print(
+                "[CROP] Skip bottom-line focus for PDF cover page (page 1).",
+                file=sys.stderr,
+                flush=True,
+            )
+        if parsed_entries and not skip_bottom_focus:
+            selected_indices = _cluster_bottom_text_entries(box_entries, arr.shape[0])
+            if selected_indices:
+                print(
+                    f"[CROP] focus bottom lines idx={selected_indices}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+        lines: List[Dict[str, Any]] = []
+        indices_to_keep = selected_indices or list(range(len(parsed_entries)))
+        for idx in indices_to_keep:
+            entry = parsed_entries[idx]
+            text_clean = entry["raw_text"]
+            converted = text_clean
+            if _OPENCC_T2S_ENABLED and _T2S_CONVERTER is not None:
+                try:
+                    converted = _T2S_CONVERTER(text_clean)
+                except Exception as exc:  # pragma: no cover
                     print(
-                        f"[REC] text='{text_clean}' score={score:.4f}",
+                        f"[REC][WARN] T2S convert failed: {exc}",
                         file=sys.stderr,
                         flush=True,
                     )
-                    lines.append({"text": text_clean, "score": score, "box": box})
+                else:
+                    print(
+                        f"[REC][T2S] simplified='{converted}' (source='{text_clean}')",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            score = entry["score"]
+            box_arr = entry["box_arr"]
+            box = box_arr.tolist() if box_arr is not None else None
+            final_text = converted
+            print(
+                f"[REC] text='{final_text}' score={score:.4f}",
+                file=sys.stderr,
+                flush=True,
+            )
+            lines.append({"text": final_text, "score": score, "box": box})
         return OcrResp(ok=True, lines=[OcrLine(**l) for l in lines])
     except Exception as e:
         err = str(e)


### PR DESCRIPTION
## Summary
- propagate metadata when decoding images so PDF requests include page information
- skip bottom-line focusing for multi-page PDF cover pages and note the decision in logs
- always log the Traditional-to-Simplified conversion result for each recognized line

## Testing
- python -m compileall ctv/orc.py

------
https://chatgpt.com/codex/tasks/task_b_68cd1aae67108326a647140c21855e9c