### PR TITLE
Fix T2S logging fallback branch indentation

### DIFF
--- a/ctv/orc.py
+++ b/ctv/orc.py
@@ -201,12 +201,12 @@ else:
             file=sys.stderr,
             flush=True,
         )
-else:
-    print(
-        "[CONFIG] Simplified logging unavailable (converter missing).",
-        file=sys.stderr,
-        flush=True,
-    )
+    else:
+        print(
+            "[CONFIG] Simplified logging unavailable (converter missing).",
+            file=sys.stderr,
+            flush=True,
+        )
 
 print(
     f"[CONFIG] recognition score threshold={REC_SCORE_MIN}",


### PR DESCRIPTION
## Summary
- fix the misplaced else branch in the T2S logging configuration to keep it scoped within the intended conditional

## Testing
- python -m py_compile ctv/orc.py

------
https://chatgpt.com/codex/tasks/task_b_68d217d320388326a956845aa43c0b32